### PR TITLE
set ubuntu version

### DIFF
--- a/.github/workflows/js-port-v9.yml
+++ b/.github/workflows/js-port-v9.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/merge-to-js.yml
+++ b/.github/workflows/merge-to-js.yml
@@ -5,7 +5,7 @@ on:
       - 'master'
 jobs:
   merge-branch:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Wait for Unix port build to succeed
         uses: fountainhead/action-wait-for-check@v1.0.0

--- a/.github/workflows/rp2_port.yml
+++ b/.github/workflows/rp2_port.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         board: [PICO]

--- a/.github/workflows/stm32_port.yml
+++ b/.github/workflows/stm32_port.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         board: [STM32F7DISC]

--- a/.github/workflows/unix_port.yml
+++ b/.github/workflows/unix_port.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
"Latest" version of ubuntu was updated for GitHub actions The new version (22.04) is missing some packages that are available on 20.04. Fix GH action version to 22.04 to prevent surprises.

Update bindings.